### PR TITLE
Add support for delaying server shutdown

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -8,7 +8,33 @@ if ! screen -list | grep -q "servername"; then
   exit 1
 fi
 
+# Get an optional custom countdown time (in minutes)
+CountdownTime=0
+while getopts ":t" opt; do
+  case $opt in
+    t)
+      case $string in
+        ''|*[!0-9]*) 
+          echo "Countdown time must be a whole number in minutes."
+          exit 1
+          ;;
+        *) 
+          CountdownTime=$OPTARG >&2 
+          ;;
+      esac
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG; countdown time must be a whole number in minutes." >&2
+      ;;
+  esac
+done
+
 # Stop the server
+while [ $CountdownTime -gt 0 ] do
+  screen -Rd servername -X stuff "say Closing server in $CountdownTime minutes...$(printf '\r')"
+  echo "Waiting for $CountdownTime more minutes ..."
+  sleep 60;
+done
 echo "Stopping Minecraft server ..."
 screen -Rd servername -X stuff "say Closing server (stop.sh called)...$(printf '\r')"
 screen -Rd servername -X stuff "stop$(printf '\r')"


### PR DESCRIPTION
Optionally specify a custom countdown time in minutes with `-t X` to delay shutting down the server