### PR TITLE
Better countdown messages

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -32,20 +32,20 @@ done
 # Stop the server
 while [ $CountdownTime -gt 0 ]; do
   if [ $CountdownTime -eq 1 ]; then
-    screen -Rd servername -X stuff "say Closing server in 60 seconds...$(printf '\r')"
+    screen -Rd servername -X stuff "say Stopping server in 60 seconds...$(printf '\r')"
     sleep 30;
-    screen -Rd servername -X stuff "say Closing server in 30 seconds...$(printf '\r')"
+    screen -Rd servername -X stuff "say Stopping server in 30 seconds...$(printf '\r')"
     sleep 20;
-    screen -Rd servername -X stuff "say Closing server in 10 seconds...$(printf '\r')"
+    screen -Rd servername -X stuff "say Stopping server in 10 seconds...$(printf '\r')"
     sleep 10;
   else
-    screen -Rd servername -X stuff "say Closing server in $CountdownTime minutes...$(printf '\r')"
+    screen -Rd servername -X stuff "say Stopping server in $CountdownTime minutes...$(printf '\r')"
     echo "Waiting for $CountdownTime more minutes ..."
     sleep 60;
   fi
 done
 echo "Stopping Minecraft server ..."
-screen -Rd servername -X stuff "say Closing server (stop.sh called)...$(printf '\r')"
+screen -Rd servername -X stuff "say Stopping server (stop.sh called)...$(printf '\r')"
 screen -Rd servername -X stuff "stop$(printf '\r')"
 
 # Wait up to 20 seconds for server to close
@@ -60,7 +60,7 @@ done
 
 # Force quit if server is still open
 if screen -list | grep -q "servername"; then
-  echo "Minecraft server still hasn't closed after 20 seconds, closing screen manually"
+  echo "Minecraft server still hasn't stopped after 20 seconds, closing screen manually"
   screen -S servername -X quit
 fi
 

--- a/stop.sh
+++ b/stop.sh
@@ -31,9 +31,18 @@ done
 
 # Stop the server
 while [ $CountdownTime -gt 0 ]; do
-  screen -Rd servername -X stuff "say Closing server in $CountdownTime minutes...$(printf '\r')"
-  echo "Waiting for $CountdownTime more minutes ..."
-  sleep 60;
+  if [ $CountdownTime -eq 1 ]; then
+    screen -Rd servername -X stuff "say Closing server in 60 seconds...$(printf '\r')"
+    sleep 30;
+    screen -Rd servername -X stuff "say Closing server in 30 seconds...$(printf '\r')"
+    sleep 20;
+    screen -Rd servername -X stuff "say Closing server in 10 seconds...$(printf '\r')"
+    sleep 10;
+  else
+    screen -Rd servername -X stuff "say Closing server in $CountdownTime minutes...$(printf '\r')"
+    echo "Waiting for $CountdownTime more minutes ..."
+    sleep 60;
+  fi
 done
 echo "Stopping Minecraft server ..."
 screen -Rd servername -X stuff "say Closing server (stop.sh called)...$(printf '\r')"

--- a/stop.sh
+++ b/stop.sh
@@ -40,9 +40,9 @@ while [ $CountdownTime -gt 0 ]; do
     sleep 10;
   else
     screen -Rd servername -X stuff "say Stopping server in $CountdownTime minutes...$(printf '\r')"
-    echo "Waiting for $CountdownTime more minutes ..."
     sleep 60;
   fi
+  echo "Waiting for $CountdownTime more minutes ..."
 done
 echo "Stopping Minecraft server ..."
 screen -Rd servername -X stuff "say Stopping server (stop.sh called)...$(printf '\r')"


### PR DESCRIPTION
Server will announce at the 30-second and 10-second mark when using a countdown, and consistently use 'stop' instead of 'close' in messages.