### PR TITLE
Hang fix on start up

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -58,3 +58,5 @@ fi
 echo "Starting Minecraft server.  To view window type screen -r servername"
 echo "To minimize the window and let the server run in the background, press Ctrl+A then Ctrl+D"
 screen -L -Logfile logs/$(date +%Y.%m.%d.%H.%M.%S).log -dmS servername /bin/bash -c "LD_LIBRARY_PATH=dirname/minecraftbe/servername dirname/minecraftbe/servername/bedrock_server"
+sleep 5
+screen -Rd servername -X stuff "weather query $(printf '\r')"


### PR DESCRIPTION
Added small NOP after start up to fix scenario where Bedrock would hang if start up failed