### PR TITLE
Fixes #36

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -10,11 +10,11 @@ fi
 
 # Check if network interfaces are up
 NetworkChecks=0
-DefaultRoute=$(route -n | awk '$4 == "UG" {print $2}')
+DefaultRoute=$(/sbin/route -n | awk '$4 == "UG" {print $2}')
 while [ -z "$DefaultRoute" ]; do
     echo "Network interface not up, will try again in 1 second";
     sleep 1;
-    DefaultRoute=$(route -n | awk '$4 == "UG" {print $2}')
+    DefaultRoute=$(/sbin/route -n | awk '$4 == "UG" {print $2}')
     NetworkChecks=$((NetworkChecks+1))
     if [ $NetworkChecks -gt 20 ]; then
         echo "Waiting for network interface to come up timed out - starting server without network connection ..."


### PR DESCRIPTION
Minecraft server fails to start as `route` is not in default PATH in Debian. This fix includes the full path for `route` - `/sbin/route`