### PR TITLE
Add valid_know_packs.json to unzip exclude

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -51,7 +51,7 @@ else
     else
         echo "New version $DownloadFile is available.  Updating Minecraft Bedrock server ..."
         wget -O "downloads/$DownloadFile" "$DownloadURL"
-        unzip -o "downloads/$DownloadFile" -x "*server.properties*" "*permissions.json*" "*whitelist.json*"
+        unzip -o "downloads/$DownloadFile" -x "*server.properties*" "*permissions.json*" "*whitelist.json*" "*valid_known_packs.json*"
     fi
 fi
 


### PR DESCRIPTION
When the server administrator has added behaviour- and resource packs to the server, they need to made known in valid_known_packs.json, thus that file should not be overwritten, once a new server version gets deployed.