### PR TITLE
Fixed backups rotate

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -32,7 +32,7 @@ if [ -d "worlds" ]; then
 fi
 
 # Rotate backups -- keep most recent 10
-ls -1tr | head -n -10 | xargs -d '\n' rm -f --
+ls -1tr backups | head -n -10 | xargs -d '\n' rm -f --
 
 # Retrieve latest version of Minecraft Bedrock dedicated server
 echo "Checking for the latest version of Minecraft Bedrock server ..."


### PR DESCRIPTION
The current line intended to rotate the backups is being preformed in the server directory. This results in removing files from the server directory and really messing things up.

Fixed this issue by only listing files in the backups directory.