### PR TITLE
Fixed and tested backups rotate 

### DIFF
--- a/SetupMinecraft.sh
+++ b/SetupMinecraft.sh
@@ -75,12 +75,6 @@ echo "It will be used in the folder name and service name..."
 
 read_with_prompt ServerName "Server Label"
 
-echo "Enter server IPV4 port (default 19132): "
-read_with_prompt PortIPV4 "Server IPV4 Port" 19132
-
-echo "Enter server IPV6 port (default 19133): "
-read_with_prompt PortIPV6 "Server IPV6 Port" 19133
-
 if [ -d "$ServerName" ]; then
   echo "Directory minecraftbe/$ServerName already exists!  Updating scripts and configuring service ..."
 
@@ -123,8 +117,6 @@ if [ -d "$ServerName" ]; then
   sudo sed -i "s/replace/$UserName/g" /etc/systemd/system/$ServerName.service
   sudo sed -i "s:dirname:$DirName:g" /etc/systemd/system/$ServerName.service
   sudo sed -i "s:servername:$ServerName:g" /etc/systemd/system/$ServerName.service
-  sed -i "/server-port=/c\server-port=$PortIPV4" server.properties
-  sed -i "/server-portv6=/c\server-portv6=$PortIPV6" server.properties
   sudo systemctl daemon-reload
   echo -n "Start Minecraft server at startup automatically (y/n)?"
   read answer < /dev/tty
@@ -153,6 +145,13 @@ if [ -d "$ServerName" ]; then
 
   exit 0
 fi
+
+# Prompt user for ports only for new installations
+echo "Enter server IPV4 port (default 19132): "
+read_with_prompt PortIPV4 "Server IPV4 Port" 19132
+
+echo "Enter server IPV6 port (default 19133): "
+read_with_prompt PortIPV6 "Server IPV6 Port" 19133
 
 # Create server directory
 echo "Creating minecraft server directory (~/minecraftbe/$ServerName)..."

--- a/SetupMinecraft.sh
+++ b/SetupMinecraft.sh
@@ -3,14 +3,16 @@
 #
 # Instructions: https://jamesachambers.com/minecraft-bedrock-edition-ubuntu-dedicated-server-guide/
 # To run the setup script use:
-# wget https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/SetupMinecraft.sh
+# wget https://raw.githubusercontent.com/RubenFixit/MinecraftBedrockServer/master/SetupMinecraft.sh
 # chmod +x SetupMinecraft.sh
 # ./SetupMinecraft.sh
 #
-# GitHub Repository: https://github.com/TheRemote/MinecraftBedrockServer
+# GitHub Repository: https://github.com/RubenFixit/MinecraftBedrockServer
 
-echo "Minecraft Bedrock Server installation script by James Chambers"
-echo "Latest version always at https://github.com/TheRemote/MinecraftBedrockServer"
+github_source=RubenFixit/MinecraftBedrockServer
+
+echo "Minecraft Bedrock Server installation script by James Chambers modified by RubenFixit"
+echo "Latest version always at https://github.com/$github_source"
 echo "Don't forget to set up port forwarding on your router!  The default port is 19132"
 
 # Function to read input from user with a prompt
@@ -95,28 +97,28 @@ if [ -d "$ServerName" ]; then
 
   # Download start.sh from repository
   echo "Grabbing start.sh from repository..."
-  wget -O start.sh https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/start.sh
+  wget -O start.sh https://raw.githubusercontent.com/$github_source/master/start.sh
   chmod +x start.sh
   sed -i "s:dirname:$DirName:g" start.sh
   sed -i "s:servername:$ServerName:g" start.sh
 
   # Download stop.sh from repository
   echo "Grabbing stop.sh from repository..."
-  wget -O stop.sh https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/stop.sh
+  wget -O stop.sh https://raw.githubusercontent.com/$github_source/master/stop.sh
   chmod +x stop.sh
   sed -i "s:dirname:$DirName:g" stop.sh
   sed -i "s:servername:$ServerName:g" stop.sh
 
   # Download restart.sh from repository
   echo "Grabbing restart.sh from repository..."
-  wget -O restart.sh https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/restart.sh
+  wget -O restart.sh https://raw.githubusercontent.com/$github_source/master/restart.sh
   chmod +x restart.sh
   sed -i "s:dirname:$DirName:g" restart.sh
   sed -i "s:servername:$ServerName:g" restart.sh
 
   # Update minecraft server service
   echo "Configuring $ServerName service..."
-  sudo wget -O /etc/systemd/system/$ServerName.service https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/minecraftbe.service
+  sudo wget -O /etc/systemd/system/$ServerName.service https://raw.githubusercontent.com/$github_source/master/minecraftbe.service
   sudo chmod +x /etc/systemd/system/$ServerName.service
   sudo sed -i "s/replace/$UserName/g" /etc/systemd/system/$ServerName.service
   sudo sed -i "s:dirname:$DirName:g" /etc/systemd/system/$ServerName.service
@@ -186,7 +188,7 @@ if [[ "$CPUArch" == *"aarch"* || "$CPUArch" == *"arm"* ]]; then
   fi
   
   # Retrieve depends.zip from GitHub repository
-  wget -O depends.zip https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/depends.zip
+  wget -O depends.zip https://raw.githubusercontent.com/$github_source/master/depends.zip
   unzip depends.zip
   sudo mkdir /lib64
   # Create soft link ld-linux-x86-64.so.2 mapped to ld-2.31.so
@@ -210,28 +212,28 @@ unzip -o "downloads/$DownloadFile"
 
 # Download start.sh from repository
 echo "Grabbing start.sh from repository..."
-wget -O start.sh https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/start.sh
+wget -O start.sh https://raw.githubusercontent.com/$github_source/master/start.sh
 chmod +x start.sh
 sed -i "s:dirname:$DirName:g" start.sh
 sed -i "s:servername:$ServerName:g" start.sh
 
 # Download stop.sh from repository
 echo "Grabbing stop.sh from repository..."
-wget -O stop.sh https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/stop.sh
+wget -O stop.sh https://raw.githubusercontent.com/$github_source/master/stop.sh
 chmod +x stop.sh
 sed -i "s:dirname:$DirName:g" stop.sh
 sed -i "s:servername:$ServerName:g" stop.sh
 
 # Download restart.sh from repository
 echo "Grabbing restart.sh from repository..."
-wget -O restart.sh https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/restart.sh
+wget -O restart.sh https://raw.githubusercontent.com/$github_source/master/restart.sh
 chmod +x restart.sh
 sed -i "s:dirname:$DirName:g" restart.sh
 sed -i "s:servername:$ServerName:g" restart.sh
 
 # Service configuration
 echo "Configuring Minecraft $ServerName service..."
-sudo wget -O /etc/systemd/system/$ServerName.service https://raw.githubusercontent.com/TheRemote/MinecraftBedrockServer/master/minecraftbe.service
+sudo wget -O /etc/systemd/system/$ServerName.service https://raw.githubusercontent.com/$github_source/master/minecraftbe.service
 sudo chmod +x /etc/systemd/system/$ServerName.service
 sudo sed -i "s/replace/$UserName/g" /etc/systemd/system/$ServerName.service
 sudo sed -i "s:dirname:$DirName:g" /etc/systemd/system/$ServerName.service

--- a/start.sh
+++ b/start.sh
@@ -32,7 +32,7 @@ if [ -d "worlds" ]; then
 fi
 
 # Rotate backups -- keep most recent 10
-ls -1tr | head -n -10 | xargs -d '\n' rm -f --
+ls -1tr -d backups/* | head -n -10 | xargs -d '\n' rm -f --
 
 # Retrieve latest version of Minecraft Bedrock dedicated server
 echo "Checking for the latest version of Minecraft Bedrock server ..."


### PR DESCRIPTION
The current line intended to rotate the backups is being preformed in the server directory. This results in removing files from the server directory and really messing things up.

Fixed this issue by changing the script to only list and remove files in the backups directory.