### PR TITLE
Fix: route command not installed by default on recent distros. Use ip…

### DIFF
--- a/SetupMinecraft.sh
+++ b/SetupMinecraft.sh
@@ -45,13 +45,12 @@ if [ $(id -u) = 0 ]; then
 fi
 
 # Install dependencies required to run Minecraft server in the background
-echo "Installing screen, unzip, sudo, net-tools, wget.."
+echo "Installing screen, unzip, sudo, wget.."
 if [ ! -n "`which sudo`" ]; then
   apt-get update && apt-get install sudo -y
 fi
 sudo apt-get update
 sudo apt-get install screen unzip wget -y
-sudo apt-get install net-tools -y
 sudo apt-get install libcurl4 -y
 sudo apt-get install openssl -y
 

--- a/start.sh
+++ b/start.sh
@@ -10,11 +10,11 @@ fi
 
 # Check if network interfaces are up
 NetworkChecks=0
-DefaultRoute=$(route -n | awk '$4 == "UG" {print $2}')
+DefaultRoute=$(ip ro sh | grep default)
 while [ -z "$DefaultRoute" ]; do
     echo "Network interface not up, will try again in 1 second";
     sleep 1;
-    DefaultRoute=$(route -n | awk '$4 == "UG" {print $2}')
+    DefaultRoute=$(ip ro sh | grep default)
     NetworkChecks=$((NetworkChecks+1))
     if [ $NetworkChecks -gt 20 ]; then
         echo "Waiting for network interface to come up timed out - starting server without network connection ..."


### PR DESCRIPTION
Hi,
Thanks for the nice script.
I've installed it on a Debian 10 VM and found that `route` command does not exist by default.
Of course one can install `net-tools` package which contains `route`, but just to check the default route can be done by `ip ro sh | grep default` instead, without installing extra packages.
HTH.
Zsolt