### PR TITLE
Support version pinning with version_pin.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you are looking for a Docker containerized version of the Minecraft Bedrock D
   <li>Sets up Minecraft as a system service with option to autostart at boot</li>
   <li>Automatic backups when server restarts</li>
   <li>Supports multiple instances -- you can run multiple Bedrock servers on the same system</li>
-  <li>Updates automatically to the latest version when server is started</li>
+  <li>Updates automatically to the latest or user-defined version when server is started</li>
   <li>Easy control of server with start.sh, stop.sh and restart.sh scripts</li>
   <li>Adds logging with timestamps to "logs" directory</li>
   <li>Optional scheduled daily restart of server using cron</li>
@@ -69,6 +69,10 @@ To run the installation type:<br>
 
 <h2>Update History</h2>
 <ul>
+  <li>May 22nd 2022</li>
+    <ul>
+        <li>Added version_pin.txt to allow for manual override of running server version. Run ./revert.sh in your server folder to set version n-1 to run on next restart. Delete version_pin.txt when you want to resume automatic updates. (thanks smallsam)</li>
+    </ul>
   <li>May 15th 2022</li>
     <ul>
         <li>Added screen -wipe to beginning of start.sh to prevent a startup issue that could occur if there was a "dead" screen instance (thanks grimholme)</li>

--- a/revert.sh
+++ b/revert.sh
@@ -1,0 +1,2 @@
+ls -r1 downloads/ | grep bedrock-server | head -2 | tail -1 > version_pin.txt
+echo "Set previous version in version_pin.txt: $(cat version_pin.txt)"

--- a/start.sh
+++ b/start.sh
@@ -92,19 +92,46 @@ else
     # Download server index.html to check latest version
 
     curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o downloads/version.html https://www.minecraft.net/en-us/download/server/bedrock
-    DownloadURL=$(grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' downloads/version.html)
+    LatestURL=$(grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' downloads/version.html)
 
-    DownloadFile=$(echo "$DownloadURL" | sed 's#.*/##')
+    LatestFile=$(echo "$LatestURL" | sed 's#.*/##')
 
-    # Download latest version of Minecraft Bedrock dedicated server if a new one is available
-    if [ -f "downloads/$DownloadFile" ]
-    then
-        echo "Minecraft Bedrock server is up to date..."
+    echo "Latest version online is $LatestFile"
+    if [ -e version_pin.txt ]; then
+        echo "version_pin.txt found with override version, using version specified: $(cat version_pin.txt)"
+            PinFile=$(cat version_pin.txt)
+    fi
+
+    if [ -e version_installed.txt ]; then
+        InstalledFile=$(cat version_installed.txt)
+        echo "Current install is: $InstalledFile"
+    fi
+
+    if [[ "$PinFile" == *"zip" ]] && [[ "$InstalledFile" == "$PinFile" ]]; then
+        echo "Requested version $PinFile is already installed"
+    elif [ ! -z "$PinFile" ]; then
+        echo "Installing $PinFile"
+        DownloadFile=$PinFile
+        DownloadURL="https://minecraft.azureedge.net/bin-linux/$PinFile"
+    elif [[ "$InstalledFile" == "$LatestFile" ]]; then
+        echo "Latest version $LatestFile is already installed"
     else
-        echo "New version $DownloadFile is available.  Updating Minecraft Bedrock server ..."
+        echo "Installing $LatestFile"
+        DownloadFile=$LatestFile
+        DownloadURL=$LatestURL
+    fi
+
+    # Download version of Minecraft Bedrock dedicated server if it's not already local
+    if [ ! -f "downloads/$DownloadFile" ]; then
         curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o "downloads/$DownloadFile" "$DownloadURL"
+    fi
+
+    # Install version of Minecraft requested
+    if [ ! -z "$DownloadFile" ]; then
         unzip -o "downloads/$DownloadFile" -x "*server.properties*" "*permissions.json*" "*whitelist.json*" "*valid_known_packs.json*" "*allowlist.json*"
         Permissions=$(chmod u+x dirname/minecraftbe/servername/bedrock_server >/dev/null)
+    fi
+        echo "$DownloadFile" > version_installed.txt
     fi
 fi
 


### PR DESCRIPTION
If you set a zip filename in version_pin.txt, on startup the server will use this version as the requested version.
It will download/install as necessary and remain on that specified version until the version_pin.txt file is removed.

A simple revert.sh script is supplied to aid in generating the correct string for the file which chooses the latest-1 version available in the downloads folder.

Fixes #122 and #123 