### PR TITLE
Fix Update URL (Issues #154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ See the following links:<br>
 
 <h2>Update History</h2>
 <ul>
+  <li>December 5th 2025</li>
+  <ul>
+    <li>Fixed download URL</li>
+  </ul>
   <li>December 1st 2024</li>
   <ul>
     <li>Fixed download URL</li>

--- a/start.sh
+++ b/start.sh
@@ -95,7 +95,7 @@ if [ "$?" != 0 ]; then
 else
     # Download server index.html to check latest version
 
-    curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o downloads/version.html https://www.minecraft.net/en-us/download/server/bedrock
+    curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o downloads/version.html https://net-secondary.web.minecraft-services.net/api/v1.0/download/links
     LatestURL=$(grep -o 'https://www.minecraft.net/bedrockdedicatedserver/bin-linux/[^"]*' downloads/version.html)
 
     LatestFile=$(echo "$LatestURL" | sed 's#.*/##')


### PR DESCRIPTION
Hi there! 👋  

I've been using this project for a while now and after browsing through the open issues, I came across [#154](https://github.com/TheRemote/MinecraftBedrockServer/issues/154), which is because they updated the URL again. Thanks to [@TylerJohnson177](https://github.com/TylerJohnson177) the Problem is already solved.

I packed it together and updated the Update History.

Hope I haven't forgot anything.