### PR TITLE
Fix latest version check URL

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -95,7 +95,7 @@ if [ "$?" != 0 ]; then
 else
     # Download server index.html to check latest version
 
-    curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o downloads/version.html https://www.minecraft.net/en-us/download/server/bedrock
+    curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o downloads/version.html https://net-secondary.web.minecraft-services.net/api/v1.0/download/links
     LatestURL=$(grep -o 'https://www.minecraft.net/bedrockdedicatedserver/bin-linux/[^"]*' downloads/version.html)
 
     LatestFile=$(echo "$LatestURL" | sed 's#.*/##')


### PR DESCRIPTION
As per #154 this patch changes the URL used to retrieve the latest version of the Bedrock server. The website previously used appears to have been changed, which breaks this check in start.sh. 